### PR TITLE
Ensuring backwards compatibility of etcdctl with pflags 

### DIFF
--- a/bool.go
+++ b/bool.go
@@ -19,6 +19,10 @@ func (b *boolValue) Set(s string) error {
 	return err
 }
 
+func (b *boolValue) Type() string {
+	return "bool"
+}
+
 func (b *boolValue) String() string { return fmt.Sprintf("%v", *b) }
 
 // BoolVar defines a bool flag with specified name, default value, and usage string.

--- a/duration.go
+++ b/duration.go
@@ -18,13 +18,6 @@ func (d *durationValue) Set(s string) error {
 
 func (d *durationValue) String() string { return (*time.Duration)(d).String() }
 
-// Value is the interface to the dynamic value stored in a flag.
-// (The default value is represented as a string.)
-type Value interface {
-	String() string
-	Set(string) error
-}
-
 // DurationVar defines a time.Duration flag with specified name, default value, and usage string.
 // The argument p points to a time.Duration variable in which to store the value of the flag.
 func (f *FlagSet) DurationVar(p *time.Duration, name string, value time.Duration, usage string) {

--- a/duration.go
+++ b/duration.go
@@ -16,6 +16,10 @@ func (d *durationValue) Set(s string) error {
 	return err
 }
 
+func (d *durationValue) Type() string {
+	return "duration"
+}
+
 func (d *durationValue) String() string { return (*time.Duration)(d).String() }
 
 // DurationVar defines a time.Duration flag with specified name, default value, and usage string.

--- a/flag.go
+++ b/flag.go
@@ -442,90 +442,90 @@ func (f *FlagSet) setFlag(flag *Flag, value string, origArg string) error {
 	return nil
 }
 
-func (f *FlagSet) parseLongArg(s string, args []string) (a []string, err error) {
-	a = args
-	if len(s) == 2 { // "--" terminates the flags
-		f.args = append(f.args, args...)
-		return
-	}
-	name := s[2:]
-	if len(name) == 0 || name[0] == '-' || name[0] == '=' {
-		err = f.failf("bad flag syntax: %s", s)
-		return
-	}
-	split := strings.SplitN(name, "=", 2)
-	name = split[0]
-	m := f.formal
-	flag, alreadythere := m[name] // BUG
-	if !alreadythere {
-		if name == "help" { // special case for nice help message.
-			f.usage()
-			return args, ErrHelp
-		}
-		err = f.failf("unknown flag: --%s", name)
-		return
-	}
-	if len(split) == 1 {
-		if _, ok := flag.Value.(*boolValue); !ok {
-			err = f.failf("flag needs an argument: %s", s)
-			return
-		}
-		f.setFlag(flag, "true", s)
-	} else {
-		if e := f.setFlag(flag, split[1], s); e != nil {
-			err = e
-			return
-		}
-	}
-	return args, nil
-}
+// func (f *FlagSet) parseLongArg(s string, args []string) (a []string, err error) {
+// a = args
+// if len(s) == 2 { // "--" terminates the flags
+// f.args = append(f.args, args...)
+// return
+// }
+// name := s[2:]
+// if len(name) == 0 || name[0] == '-' || name[0] == '=' {
+// err = f.failf("bad flag syntax: %s", s)
+// return
+// }
+// split := strings.SplitN(name, "=", 2)
+// name = split[0]
+// m := f.formal
+// flag, alreadythere := m[name] // BUG
+// if !alreadythere {
+// if name == "help" { // special case for nice help message.
+// f.usage()
+// return args, ErrHelp
+// }
+// err = f.failf("unknown flag: --%s", name)
+// return
+// }
+// if len(split) == 1 {
+// if _, ok := flag.Value.(*boolValue); !ok {
+// err = f.failf("flag needs an argument: %s", s)
+// return
+// }
+// f.setFlag(flag, "true", s)
+// } else {
+// if e := f.setFlag(flag, split[1], s); e != nil {
+// err = e
+// return
+// }
+// }
+// return args, nil
+// }
 
-func (f *FlagSet) parseShortArg(s string, args []string) (a []string, err error) {
-	a = args
-	shorthands := s[1:]
+// func (f *FlagSet) parseShortArg(s string, args []string) (a []string, err error) {
+// 	a = args
+// 	shorthands := s[1:]
 
-	for i := 0; i < len(shorthands); i++ {
-		c := shorthands[i]
-		flag, alreadythere := f.shorthands[c]
-		if !alreadythere {
-			if c == 'h' { // special case for nice help message.
-				f.usage()
-				err = ErrHelp
-				return
-			}
-			//TODO continue on error
-			err = f.failf("unknown shorthand flag: %q in -%s", c, shorthands)
-			if len(args) == 0 {
-				return
-			}
-		}
-		if alreadythere {
-			if _, ok := flag.Value.(*boolValue); ok {
-				f.setFlag(flag, "true", s)
-				continue
-			}
-			if i < len(shorthands)-1 {
-				if e := f.setFlag(flag, shorthands[i+1:], s); e != nil {
-					err = e
-					return
-				}
-				break
-			}
-			if len(args) == 0 {
-				err = f.failf("flag needs an argument: %q in -%s", c, shorthands)
-				return
-			}
-			if e := f.setFlag(flag, args[0], s); e != nil {
-				err = e
-				return
-			}
-		}
-		a = args[1:]
-		break // should be unnecessary
-	}
+// 	for i := 0; i < len(shorthands); i++ {
+// 		c := shorthands[i]
+// 		flag, alreadythere := f.shorthands[c]
+// 		if !alreadythere {
+// 			if c == 'h' { // special case for nice help message.
+// 				f.usage()
+// 				err = ErrHelp
+// 				return
+// 			}
+// 			//TODO continue on error
+// 			err = f.failf("unknown shorthand flag: %q in -%s", c, shorthands)
+// 			if len(args) == 0 {
+// 				return
+// 			}
+// 		}
+// 		if alreadythere {
+// 			if _, ok := flag.Value.(*boolValue); ok {
+// 				f.setFlag(flag, "true", s)
+// 				continue
+// 			}
+// 			if i < len(shorthands)-1 {
+// 				if e := f.setFlag(flag, shorthands[i+1:], s); e != nil {
+// 					err = e
+// 					return
+// 				}
+// 				break
+// 			}
+// 			if len(args) == 0 {
+// 				err = f.failf("flag needs an argument: %q in -%s", c, shorthands)
+// 				return
+// 			}
+// 			if e := f.setFlag(flag, args[0], s); e != nil {
+// 				err = e
+// 				return
+// 			}
+// 		}
+// 		a = args[1:]
+// 		break // should be unnecessary
+// 	}
 
-	return
-}
+// 	return
+// }
 
 func (f *FlagSet) parseArgs(args []string) (err error) {
 	for len(args) > 0 {
@@ -542,12 +542,69 @@ func (f *FlagSet) parseArgs(args []string) (err error) {
 		}
 
 		if s[1] == '-' {
-			args, err = f.parseLongArg(s, args)
+			if len(s) == 2 { // "--" terminates the flags
+				f.args = append(f.args, args...)
+				return nil
+			}
+			name := s[2:]
+			if len(name) == 0 || name[0] == '-' || name[0] == '=' {
+				return f.failf("bad flag syntax: %s", s)
+			}
+			split := strings.SplitN(name, "=", 2)
+			name = split[0]
+			m := f.formal
+			flag, alreadythere := m[name] // BUG
+			if !alreadythere {
+				if name == "help" { // special case for nice help message.
+					f.usage()
+					return ErrHelp
+				}
+				return f.failf("unknown flag: --%s", name)
+			}
+			if len(split) == 1 {
+				if _, ok := flag.Value.(*boolValue); !ok {
+					return f.failf("flag needs an argument: %s", s)
+				}
+				f.setFlag(flag, "true", s)
+			} else {
+				if err := f.setFlag(flag, split[1], s); err != nil {
+					return err
+				}
+			}
 		} else {
-			args, err = f.parseShortArg(s, args)
+			shorthands := s[1:]
+			for i := 0; i < len(shorthands); i++ {
+				c := shorthands[i]
+				flag, alreadythere := f.shorthands[c]
+				if !alreadythere {
+					if c == 'h' { // special case for nice help message.
+						f.usage()
+						return ErrHelp
+					}
+					return f.failf("unknown shorthand flag: %q in -%s", c, shorthands)
+				}
+				if _, ok := flag.Value.(*boolValue); ok {
+					f.setFlag(flag, "true", s)
+					continue
+				}
+				if i < len(shorthands)-1 {
+					if err := f.setFlag(flag, shorthands[i+1:], s); err != nil {
+						return err
+					}
+					break
+				}
+				if len(args) == 0 {
+					return f.failf("flag needs an argument: %q in -%s", c, shorthands)
+				}
+				if err := f.setFlag(flag, args[0], s); err != nil {
+					return err
+				}
+				args = args[1:]
+				break // should be unnecessary
+			}
 		}
 	}
-	return
+	return nil
 }
 
 // Parse parses flag definitions from the argument list, which should not

--- a/flag.go
+++ b/flag.go
@@ -527,7 +527,7 @@ func (f *FlagSet) setFlag(flag *Flag, value string, origArg string) error {
 // 	return
 // }
 
-func (f *FlagSet) parseLongFlag(args []string) (err error) {
+func (f *FlagSet) parseLongFlag(flag *Flag, split []string, args []string, s string) (err error) {
 
 	if len(split) == 1 {
 		if _, ok := flag.Value.(*boolValue); !ok {
@@ -550,44 +550,44 @@ func (f *FlagSet) parseLongFlag(args []string) (err error) {
 			// but still look to see if a value specified for it is true
 			// or false or any variant of them as listed below.
 
-			if len(args) > 0 {
-				switch args[0] {
-				case "false":
-					fallthrough
-				case "False":
-					fallthrough
-				case "FALSE":
-					fallthrough
-				case "0":
-					fallthrough
-				case "f":
-					fallthrough
-				case "F":
-					f.setFlag(flag, "false", s)
-					args = args[1:]
-					return f.parseArgs(args)
-					break
-				case "true":
-					fallthrough
-				case "True":
-					fallthrough
-				case "TRUE":
-					fallthrough
-				case "1":
-					fallthrough
-				case "t":
-					fallthrough
-				case "T":
-					f.setFlag(flag, "true", s)
-					args = args[1:]
-					return f.parseArgs(args)
+			// if len(args) > 0 {
+			// 	switch args[0] {
+			// 	case "false":
+			// 		fallthrough
+			// 	case "False":
+			// 		fallthrough
+			// 	case "FALSE":
+			// 		fallthrough
+			// 	case "0":
+			// 		fallthrough
+			// 	case "f":
+			// 		fallthrough
+			// 	case "F":
+			// 		f.setFlag(flag, "false", s)
+			// 		args = args[1:]
+			// 		return f.parseArgs(args)
+			// 		break
+			// 	case "true":
+			// 		fallthrough
+			// 	case "True":
+			// 		fallthrough
+			// 	case "TRUE":
+			// 		fallthrough
+			// 	case "1":
+			// 		fallthrough
+			// 	case "t":
+			// 		fallthrough
+			// 	case "T":
+			// 		f.setFlag(flag, "true", s)
+			// 		args = args[1:]
+			// 		return f.parseArgs(args)
 
-				}
-			} else {
+			// 	}
+			// } else {
 
-				f.setFlag(flag, "true", s)
+			f.setFlag(flag, "true", s)
 
-			}
+			// }
 		}
 
 	} else {
@@ -632,70 +632,73 @@ func (f *FlagSet) parseArgs(args []string) (err error) {
 				}
 				return f.failf("unknown flag: --%s", name)
 			}
-			if len(split) == 1 {
-				if _, ok := flag.Value.(*boolValue); !ok {
 
-					// if len of args == 0 report error.
+			f.parseLongFlag(flag, split, args, s)
 
-					if len(args) == 0 {
-						return f.failf("flag needs an argument: %s", s)
-					}
+			// if len(split) == 1 {
+			// 	if _, ok := flag.Value.(*boolValue); !ok {
 
-					// this is the case where a space follows a long-form flag.
-					if err := f.setFlag(flag, args[0], s); err != nil {
-						return err
-					}
+			// 		// if len of args == 0 report error.
 
-					args = args[1:] // we've used the value up.
+			// 		if len(args) == 0 {
+			// 			return f.failf("flag needs an argument: %s", s)
+			// 		}
 
-				} else {
-					// if it is a boolean value then set it to true by default:
-					// but still look to see if a value specified for it is true
-					// or false or any variant of them as listed below.
+			// 		// this is the case where a space follows a long-form flag.
+			// 		if err := f.setFlag(flag, args[0], s); err != nil {
+			// 			return err
+			// 		}
 
-					if len(args) > 0 {
-						switch args[0] {
-						case "false":
-							fallthrough
-						case "False":
-							fallthrough
-						case "FALSE":
-							fallthrough
-						case "0":
-							fallthrough
-						case "f":
-							fallthrough
-						case "F":
-							f.setFlag(flag, "false", s)
-							args = args[1:]
-							break
-						case "true":
-							fallthrough
-						case "True":
-							fallthrough
-						case "TRUE":
-							fallthrough
-						case "1":
-							fallthrough
-						case "t":
-							fallthrough
-						case "T":
-							f.setFlag(flag, "true", s)
-							args = args[1:]
+			// 		args = args[1:] // we've used the value up.
 
-						}
-					} else {
+			// 	} else {
+			// 		// if it is a boolean value then set it to true by default:
+			// 		// but still look to see if a value specified for it is true
+			// 		// or false or any variant of them as listed below.
 
-						f.setFlag(flag, "true", s)
+			// 		if len(args) > 0 {
+			// 			switch args[0] {
+			// 			case "false":
+			// 				fallthrough
+			// 			case "False":
+			// 				fallthrough
+			// 			case "FALSE":
+			// 				fallthrough
+			// 			case "0":
+			// 				fallthrough
+			// 			case "f":
+			// 				fallthrough
+			// 			case "F":
+			// 				f.setFlag(flag, "false", s)
+			// 				args = args[1:]
+			// 				break
+			// 			case "true":
+			// 				fallthrough
+			// 			case "True":
+			// 				fallthrough
+			// 			case "TRUE":
+			// 				fallthrough
+			// 			case "1":
+			// 				fallthrough
+			// 			case "t":
+			// 				fallthrough
+			// 			case "T":
+			// 				f.setFlag(flag, "true", s)
+			// 				args = args[1:]
 
-					}
-				}
+			// 			}
+			// 		} else {
 
-			} else {
-				if err := f.setFlag(flag, split[1], s); err != nil {
-					return err
-				}
-			}
+			// 			f.setFlag(flag, "true", s)
+
+			// 		}
+			// 	}
+
+			// } else {
+			// 	if err := f.setFlag(flag, split[1], s); err != nil {
+			// 		return err
+			// 	}
+			// }
 		} else {
 
 			shorthand := s[1:] //single-dash preceded flag name + value
@@ -710,17 +713,20 @@ func (f *FlagSet) parseArgs(args []string) (err error) {
 			flag, alreadythere = f.formal[name]
 
 			if alreadythere {
-
+				return f.parseLongFlag(flag, split, args, s)
 			}
+
+			//if it's here that means long flag was not found ; check for short flag.
 
 			if flag, alreadythere = f.shorthands[name[0]]; len(name) == 1 && alreadythere {
 
 			}
 
-			flagFormal, alreadythereFormal := f.formal[name]
 			flag, alreadythere := f.shorthands[name[0]]
 			// if both are false then provide an error message.
-			if alreadythere == false && alreadythereFormal == false {
+			// it's also an error if the short flag is present but name is of more than one char
+			// if length is more than one then we should have found it in the f.formal maps
+			if !alreadythere || len(name) > 1 {
 
 				if name == "help" || name == "h" {
 					f.usage()

--- a/flag.go
+++ b/flag.go
@@ -460,7 +460,7 @@ func (f *FlagSet) parseFlag(flag *Flag, split []string, args []string, s string)
 			return err
 		}
 	}
-
+	fmt.Printf("Flag %v set to %v\n", flag.Name, flag.Value)
 	return f.parseArgs(args)
 
 }
@@ -468,6 +468,7 @@ func (f *FlagSet) parseFlag(flag *Flag, split []string, args []string, s string)
 func (f *FlagSet) parseArgs(args []string) (err error) {
 	for len(args) > 0 {
 		s := args[0]
+		fmt.Println("args[0] is ", s)
 		args = args[1:]
 		if len(s) == 0 || s[0] != '-' || len(s) == 1 {
 			if !f.interspersed {
@@ -475,7 +476,9 @@ func (f *FlagSet) parseArgs(args []string) (err error) {
 				f.args = append(f.args, args...)
 				return nil
 			}
+
 			f.args = append(f.args, s)
+			fmt.Println("Args is currently ", f.args)
 			continue
 		}
 
@@ -534,7 +537,7 @@ func (f *FlagSet) parseArgs(args []string) (err error) {
 
 				return f.failf("unknown  flag: %s in -%s", name, shorthand)
 			}
-
+			fmt.Println("parsing short flag ", flag.Name)
 			return f.parseFlag(flag, split, args, s) // because the short and long flags are the same.
 
 		}

--- a/flag.go
+++ b/flag.go
@@ -460,7 +460,7 @@ func (f *FlagSet) parseFlag(flag *Flag, split []string, args []string, s string)
 			return err
 		}
 	}
-	fmt.Printf("Flag %v set to %v\n", flag.Name, flag.Value)
+	// fmt.Printf("Flag %v set to %v\n", flag.Name, flag.Value)
 	return f.parseArgs(args)
 
 }
@@ -468,7 +468,7 @@ func (f *FlagSet) parseFlag(flag *Flag, split []string, args []string, s string)
 func (f *FlagSet) parseArgs(args []string) (err error) {
 	for len(args) > 0 {
 		s := args[0]
-		fmt.Println("args[0] is ", s)
+		// fmt.Println("args[0] is ", s)
 		args = args[1:]
 		if len(s) == 0 || s[0] != '-' || len(s) == 1 {
 			if !f.interspersed {
@@ -478,7 +478,7 @@ func (f *FlagSet) parseArgs(args []string) (err error) {
 			}
 
 			f.args = append(f.args, s)
-			fmt.Println("Args is currently ", f.args)
+			// fmt.Println("Args is currently ", f.args)
 			continue
 		}
 
@@ -522,7 +522,7 @@ func (f *FlagSet) parseArgs(args []string) (err error) {
 				return f.parseFlag(flag, split, args, s)
 			}
 
-			//if it's here that means long flag was not found ; check for short flag.
+			//if program reaches this point means long flag was not found ; check for short flag.
 
 			flag, alreadythere = f.shorthands[name[0]]
 			// if both are false then provide an error message.
@@ -537,7 +537,7 @@ func (f *FlagSet) parseArgs(args []string) (err error) {
 
 				return f.failf("unknown  flag: %s in -%s", name, shorthand)
 			}
-			fmt.Println("parsing short flag ", flag.Name)
+			// fmt.Println("parsing short flag ", flag.Name)
 			return f.parseFlag(flag, split, args, s) // because the short and long flags are the same.
 
 		}

--- a/flag.go
+++ b/flag.go
@@ -993,15 +993,11 @@ func (f *FlagSet) parseLongArg(s string, args []string) (a []string, err error) 
 func (f *FlagSet) parseShortArg(s string, args []string) (a []string, err error) {
 	a = args
 	shorthands := s[1:]
-	//fmt.Println("shorthands", shorthands)
-	//fmt.Print("all shorthands", f.shorthands)
+
 	for i := 0; i < len(shorthands); i++ {
 		c := shorthands[i]
-		//fmt.Println("c", c)
 		flag, alreadythere := f.shorthands[c]
-		//fmt.Println(alreadythere)
 		if !alreadythere {
-			//fmt.Println("not there")
 			if c == 'h' { // special case for nice help message.
 				f.usage()
 				err = ErrHelp
@@ -1009,6 +1005,9 @@ func (f *FlagSet) parseShortArg(s string, args []string) (a []string, err error)
 			}
 			//TODO continue on error
 			err = f.failf("unknown shorthand flag: %q in -%s", c, shorthands)
+			if len(args) == 0 {
+				return
+			}
 		}
 		if alreadythere {
 			if _, ok := flag.Value.(*boolValue); ok {
@@ -1039,7 +1038,6 @@ func (f *FlagSet) parseShortArg(s string, args []string) (a []string, err error)
 }
 
 func (f *FlagSet) parseArgs(args []string) (err error) {
-	//fmt.Println(args)
 	for len(args) > 0 {
 		s := args[0]
 		args = args[1:]

--- a/flag.go
+++ b/flag.go
@@ -282,6 +282,7 @@ type Flag struct {
 	Usage     string // help message
 	Value     Value  // value as set
 	DefValue  string // default value (as text); for usage message
+	Changed   bool   // If the user set the value (or if left to default)
 }
 
 // sortFlags returns the flags as a slice in lexicographical sorted order.
@@ -370,6 +371,7 @@ func (f *FlagSet) Set(name, value string) error {
 		f.actual = make(map[string]*Flag)
 	}
 	f.actual[name] = flag
+	f.Lookup(name).Changed = true
 	return nil
 }
 
@@ -868,7 +870,7 @@ func (f *FlagSet) Var(value Value, name string, usage string) {
 // Like Var, but accepts a shorthand letter that can be used after a single dash.
 func (f *FlagSet) VarP(value Value, name, shorthand, usage string) {
 	// Remember the default value as a string; it won't change.
-	flag := &Flag{name, shorthand, usage, value, value.String()}
+	flag := &Flag{name, shorthand, usage, value, value.String(), false}
 	f.AddFlag(flag)
 }
 
@@ -948,7 +950,7 @@ func (f *FlagSet) setFlag(flag *Flag, value string, origArg string) error {
 		f.actual = make(map[string]*Flag)
 	}
 	f.actual[flag.Name] = flag
-
+	flag.Changed = true
 	return nil
 }
 

--- a/flag.go
+++ b/flag.go
@@ -154,6 +154,7 @@ type Flag struct {
 type Value interface {
 	String() string
 	Set(string) error
+	Type() string
 }
 
 // sortFlags returns the flags as a slice in lexicographical sorted order.

--- a/flag.go
+++ b/flag.go
@@ -149,6 +149,13 @@ type Flag struct {
 	Changed   bool   // If the user set the value (or if left to default)
 }
 
+// Value is the interface to the dynamic value stored in a flag.
+// (The default value is represented as a string.)
+type Value interface {
+	String() string
+	Set(string) error
+}
+
 // sortFlags returns the flags as a slice in lexicographical sorted order.
 func sortFlags(flags map[string]*Flag) []*Flag {
 	list := make(sort.StringSlice, len(flags))

--- a/flag.go
+++ b/flag.go
@@ -379,7 +379,7 @@ func (f *FlagSet) AddFlag(flag *Flag) {
 	c := flag.Shorthand[0]
 	old, alreadythere := f.shorthands[c]
 	if alreadythere {
-		fmt.Fprintf(f.out(), "%s shorthand reused: %q for %s already used for %s\n", f.name, c, name, old.Name)
+		fmt.Fprintf(f.out(), "%s shorthand reused: %q for %s already used for %s\n", f.name, c, flag.Name, old.Name)
 		panic("shorthand redefinition")
 	}
 	f.shorthands[c] = flag

--- a/flag.go
+++ b/flag.go
@@ -431,34 +431,25 @@ func (f *FlagSet) setFlag(flag *Flag, value string, origArg string) error {
 }
 
 func (f *FlagSet) parseFlag(flag *Flag, split []string, args []string, s string) (err error) {
-
-	if len(split) == 1 {
+	if len(split) == 1 { // space follows a long-form flag.
 		if _, ok := flag.Value.(*boolValue); !ok {
 			if len(args) == 0 {
 				return f.failf("flag needs an argument: %s", s)
 			}
-
-			// this is the case where a space follows a long-form flag.
 			if err := f.setFlag(flag, args[0], s); err != nil {
 				return err
 			}
-
-			args = args[1:] // we've used the value up.
-
+			args = args[1:]
 		} else {
-
 			// no spaces allowed for boolean
 			f.setFlag(flag, "true", s)
 		}
-
 	} else {
 		if err := f.setFlag(flag, split[1], s); err != nil {
 			return err
 		}
 	}
-
 	return f.parseArgs(args)
-
 }
 
 func (f *FlagSet) parseArgs(args []string) (err error) {

--- a/flag.go
+++ b/flag.go
@@ -67,18 +67,6 @@
 		--flag    // boolean flags only
 		--flag=x
 
-	Unlike the flag package, a single dash before an option means something
-	different than a double dash. Single dashes signify a series of shorthand
-	letters for flags. All but the last shorthand letter must be boolean flags.
-		// boolean flags
-		-f
-		-abc
-		// non-boolean flags
-		-n 1234
-		-Ifile
-		// mixed
-		-abcs "hello"
-		-abcn1234
 
 	Flag parsing stops after the terminator "--". Unlike the flag package,
 	flags can be interspersed with arguments anywhere on the command line
@@ -442,112 +430,116 @@ func (f *FlagSet) setFlag(flag *Flag, value string, origArg string) error {
 	return nil
 }
 
-func (f *FlagSet) parseLongArg(s string, args []string) (a []string, err error) {
-	a = args
-	if len(s) == 2 { // "--" terminates the flags
-		f.args = append(f.args, args...)
-		return
-	}
-	name := s[2:]
-	if len(name) == 0 || name[0] == '-' || name[0] == '=' {
-		err = f.failf("bad flag syntax: %s", s)
-		return
-	}
-	split := strings.SplitN(name, "=", 2)
-	name = split[0]
-	m := f.formal
-	flag, alreadythere := m[name] // BUG
-	if !alreadythere {
-		if name == "help" { // special case for nice help message.
-			f.usage()
-			return args, ErrHelp
-		}
-		err = f.failf("unknown flag: --%s", name)
-		return
-	}
+func (f *FlagSet) parseFlag(flag *Flag, split []string, args []string, s string) (err error) {
+
 	if len(split) == 1 {
 		if _, ok := flag.Value.(*boolValue); !ok {
-			err = f.failf("flag needs an argument: %s", s)
-			return
+
+			if len(args) == 0 {
+				return f.failf("flag needs an argument: %s", s)
+			}
+
+			// this is the case where a space follows a long-form flag.
+			if err := f.setFlag(flag, args[0], s); err != nil {
+				return err
+			}
+
+			args = args[1:] // we've used the value up.
+
+		} else {
+
+			// no spaces allowed for boolean
+			f.setFlag(flag, "true", s)
 		}
-		f.setFlag(flag, "true", s)
+
 	} else {
-		if e := f.setFlag(flag, split[1], s); e != nil {
-			err = e
-			return
+		if err := f.setFlag(flag, split[1], s); err != nil {
+			return err
 		}
 	}
-	return args, nil
-}
+	return f.parseArgs(args)
 
-func (f *FlagSet) parseShortArg(s string, args []string) (a []string, err error) {
-	a = args
-	shorthands := s[1:]
-
-	for i := 0; i < len(shorthands); i++ {
-		c := shorthands[i]
-		flag, alreadythere := f.shorthands[c]
-		if !alreadythere {
-			if c == 'h' { // special case for nice help message.
-				f.usage()
-				err = ErrHelp
-				return
-			}
-			//TODO continue on error
-			err = f.failf("unknown shorthand flag: %q in -%s", c, shorthands)
-			if len(args) == 0 {
-				return
-			}
-		}
-		if alreadythere {
-			if _, ok := flag.Value.(*boolValue); ok {
-				f.setFlag(flag, "true", s)
-				continue
-			}
-			if i < len(shorthands)-1 {
-				if e := f.setFlag(flag, shorthands[i+1:], s); e != nil {
-					err = e
-					return
-				}
-				break
-			}
-			if len(args) == 0 {
-				err = f.failf("flag needs an argument: %q in -%s", c, shorthands)
-				return
-			}
-			if e := f.setFlag(flag, args[0], s); e != nil {
-				err = e
-				return
-			}
-		}
-		a = args[1:]
-		break // should be unnecessary
-	}
-
-	return
 }
 
 func (f *FlagSet) parseArgs(args []string) (err error) {
+
 	for len(args) > 0 {
 		s := args[0]
 		args = args[1:]
 		if len(s) == 0 || s[0] != '-' || len(s) == 1 {
 			if !f.interspersed {
+
 				f.args = append(f.args, s)
 				f.args = append(f.args, args...)
 				return nil
 			}
+
 			f.args = append(f.args, s)
+
 			continue
 		}
 
 		if s[1] == '-' {
-			args, err = f.parseLongArg(s, args)
+			if len(s) == 2 { // "--" terminates the flags
+				f.args = append(f.args, args...)
+				return nil
+			}
+			name := s[2:]
+			if len(name) == 0 || name[0] == '-' || name[0] == '=' {
+				return f.failf("bad flag syntax: %s", s)
+			}
+			split := strings.SplitN(name, "=", 2)
+			name = split[0]
+			m := f.formal
+			flag, alreadythere := m[name] // BUG
+			if !alreadythere {
+				if name == "help" { // special case for nice help message.
+					f.usage()
+					return ErrHelp
+				}
+				return f.failf("unknown flag: --%s", name)
+			}
+
+			return f.parseFlag(flag, split, args, s)
+
 		} else {
-			args, err = f.parseShortArg(s, args)
+
+			shorthand := s[1:] //single-dash preceded flag name + value
+			if len(shorthand) == 0 || shorthand[0] == '=' {
+				return f.failf("bad flag syntax: %s", s)
+			}
+			split := strings.SplitN(shorthand, "=", 2)
+			name := split[0]
+			var flag *Flag
+			var alreadythere bool
+
+			flag, alreadythere = f.formal[name]
+
+			if alreadythere {
+				return f.parseFlag(flag, split, args, s)
+			}
+
+			//if program reaches this point means long flag was not found ; check for short flag.
+
+			flag, alreadythere = f.shorthands[name[0]]
+			// if both are false then provide an error message.
+			// it's also an error if the short flag is present but name is of more than one char
+			// if length is more than one then we should have found it in the f.formal maps
+			if len(name) > 1 || !alreadythere {
+
+				if name == "help" || name == "h" {
+					f.usage()
+					return ErrHelp
+				}
+
+				return f.failf("unknown flag: %s in -%s", name, shorthand)
+			}
+
+			return f.parseFlag(flag, split, args, s)
+
 		}
 	}
-	return
+	return nil
 }
 
 // Parse parses flag definitions from the argument list, which should not
@@ -569,6 +561,7 @@ func (f *FlagSet) Parse(arguments []string) error {
 		}
 	}
 	return nil
+
 }
 
 // Parsed reports whether f.Parse has been called.

--- a/flag_test.go
+++ b/flag_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/joshi4/pflag"
+	. "github.com/spf13/pflag"
 )
 
 var (

--- a/flag_test.go
+++ b/flag_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/spf13/pflag"
+	. "github.com/joshi4/pflag"
 )
 
 var (
@@ -197,7 +197,7 @@ func TestShorthand(t *testing.T) {
 		notaflag,
 	}
 	f.SetOutput(ioutil.Discard)
-	if err := f.Parse(args); err == nil {
+	if err := f.Parse(args); err != nil {
 		t.Error("--i-look-like-a-flag should throw an error")
 	}
 	if !f.Parsed() {
@@ -243,6 +243,10 @@ func (f *flagVar) String() string {
 func (f *flagVar) Set(value string) error {
 	*f = append(*f, value)
 	return nil
+}
+
+func (f *flagVar) Type() string {
+	return "user-defined flag type is a slice of strings"
 }
 
 func TestUserDefined(t *testing.T) {

--- a/flag_test.go
+++ b/flag_test.go
@@ -7,13 +7,14 @@ package pflag_test
 import (
 	"bytes"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"sort"
 	"strings"
 	"testing"
 	"time"
 
-	. "github.com/ogier/pflag"
+	. "github.com/spf13/pflag"
 )
 
 var (
@@ -195,8 +196,9 @@ func TestShorthand(t *testing.T) {
 		"--",
 		notaflag,
 	}
-	if err := f.Parse(args); err != nil {
-		t.Fatal(err)
+	f.SetOutput(ioutil.Discard)
+	if err := f.Parse(args); err == nil {
+		t.Error("--i-look-like-a-flag should throw an error")
 	}
 	if !f.Parsed() {
 		t.Error("f.Parse() = false after Parse")

--- a/flag_test.go
+++ b/flag_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/joshi4/pflag"
+	. "github.com/coreos/pflag"
 )
 
 var (
@@ -186,19 +186,21 @@ func TestShorthand(t *testing.T) {
 	boolbFlag := f.BoolP("boolb", "b", false, "bool2 value")
 	boolcFlag := f.BoolP("boolc", "c", false, "bool3 value")
 	stringFlag := f.StringP("string", "s", "0", "string value")
-	extra := "interspersed-argument"
+	extra := "something extra"
 	notaflag := "--i-look-like-a-flag"
 	args := []string{
-		"-ab",
-		extra,
-		"-cs",
+		"-a",
+		"-b",
+		"-c",
+		"-s",
 		"hello",
 		"--",
+		extra,
 		notaflag,
 	}
 	f.SetOutput(ioutil.Discard)
 	if err := f.Parse(args); err != nil {
-		t.Error("--i-look-like-a-flag should throw an error")
+		t.Error("--i-look-like-a-flag is after the flag terminator, and hence should not throw an error")
 	}
 	if !f.Parsed() {
 		t.Error("f.Parse() = false after Parse")
@@ -216,7 +218,7 @@ func TestShorthand(t *testing.T) {
 		t.Error("string flag should be `hello`, is ", *stringFlag)
 	}
 	if len(f.Args()) != 2 {
-		t.Error("expected one argument, got", len(f.Args()))
+		t.Error("expected two arguments, got", len(f.Args()))
 	} else if f.Args()[0] != extra {
 		t.Errorf("expected argument %q got %q", extra, f.Args()[0])
 	} else if f.Args()[1] != notaflag {
@@ -254,7 +256,7 @@ func TestUserDefined(t *testing.T) {
 	flags.Init("test", ContinueOnError)
 	var v flagVar
 	flags.VarP(&v, "v", "v", "usage")
-	if err := flags.Parse([]string{"--v=1", "-v2", "-v", "3"}); err != nil {
+	if err := flags.Parse([]string{"--v=1", "-v=2", "-v", "3"}); err != nil {
 		t.Error(err)
 	}
 	if len(v) != 3 {

--- a/float32.go
+++ b/float32.go
@@ -19,6 +19,10 @@ func (f *float32Value) Set(s string) error {
 	return err
 }
 
+func (f *float32Value) Type() string {
+	return "float32"
+}
+
 func (f *float32Value) String() string { return fmt.Sprintf("%v", *f) }
 
 // Float32Var defines a float32 flag with specified name, default value, and usage string.

--- a/float64.go
+++ b/float64.go
@@ -19,6 +19,10 @@ func (f *float64Value) Set(s string) error {
 	return err
 }
 
+func (f *float64Value) Type() string {
+	return "float64"
+}
+
 func (f *float64Value) String() string { return fmt.Sprintf("%v", *f) }
 
 // Float64Var defines a float64 flag with specified name, default value, and usage string.

--- a/int.go
+++ b/int.go
@@ -19,6 +19,10 @@ func (i *intValue) Set(s string) error {
 	return err
 }
 
+func (i *intValue) Type() string {
+	return "int"
+}
+
 func (i *intValue) String() string { return fmt.Sprintf("%v", *i) }
 
 // IntVar defines an int flag with specified name, default value, and usage string.

--- a/int32.go
+++ b/int32.go
@@ -19,6 +19,10 @@ func (i *int32Value) Set(s string) error {
 	return err
 }
 
+func (i *int32Value) Type() string {
+	return "int32"
+}
+
 func (i *int32Value) String() string { return fmt.Sprintf("%v", *i) }
 
 // Int32Var defines an int32 flag with specified name, default value, and usage string.

--- a/int64.go
+++ b/int64.go
@@ -19,6 +19,10 @@ func (i *int64Value) Set(s string) error {
 	return err
 }
 
+func (i *int64Value) Type() string {
+	return "int64"
+}
+
 func (i *int64Value) String() string { return fmt.Sprintf("%v", *i) }
 
 // Int64Var defines an int64 flag with specified name, default value, and usage string.

--- a/int8.go
+++ b/int8.go
@@ -19,6 +19,10 @@ func (i *int8Value) Set(s string) error {
 	return err
 }
 
+func (i *int8Value) Type() string {
+	return "int8"
+}
+
 func (i *int8Value) String() string { return fmt.Sprintf("%v", *i) }
 
 // Int8Var defines an int8 flag with specified name, default value, and usage string.

--- a/ip.go
+++ b/ip.go
@@ -26,6 +26,10 @@ func (i *ipValue) Get() interface{} {
 	return net.IP(*i)
 }
 
+func (i *ipValue) Type() string {
+	return "ip"
+}
+
 // IPVar defines an net.IP flag with specified name, default value, and usage string.
 // The argument p points to an net.IP variable in which to store the value of the flag.
 func (f *FlagSet) IPVar(p *net.IP, name string, value net.IP, usage string) {

--- a/ipmask.go
+++ b/ipmask.go
@@ -26,6 +26,10 @@ func (i *ipMaskValue) Get() interface{} {
 	return net.IPMask(*i)
 }
 
+func (i *ipMaskValue) Type() string {
+	return "ipMask"
+}
+
 // Parse IPv4 netmask written in IP form (e.g. 255.255.255.0).
 // This function should really belong to the net package.
 func ParseIPv4Mask(s string) net.IPMask {

--- a/string.go
+++ b/string.go
@@ -14,6 +14,9 @@ func (s *stringValue) Set(val string) error {
 	*s = stringValue(val)
 	return nil
 }
+func (s *stringValue) Type() string {
+	return "string"
+}
 
 func (s *stringValue) String() string { return fmt.Sprintf("%s", *s) }
 

--- a/uint.go
+++ b/uint.go
@@ -19,6 +19,10 @@ func (i *uintValue) Set(s string) error {
 	return err
 }
 
+func (i *uintValue) Type() string {
+	return "uint"
+}
+
 func (i *uintValue) String() string { return fmt.Sprintf("%v", *i) }
 
 // UintVar defines a uint flag with specified name, default value, and usage string.

--- a/uint16.go
+++ b/uint16.go
@@ -18,8 +18,13 @@ func (i *uint16Value) Set(s string) error {
 	*i = uint16Value(v)
 	return err
 }
+
 func (i *uint16Value) Get() interface{} {
 	return uint16(*i)
+}
+
+func (i *uint16Value) Type() string {
+	return "uint16"
 }
 
 // Uint16Var defines a uint flag with specified name, default value, and usage string.

--- a/uint32.go
+++ b/uint32.go
@@ -22,6 +22,10 @@ func (i *uint32Value) Get() interface{} {
 	return uint32(*i)
 }
 
+func (i *uint32Value) Type() string {
+	return "uint32"
+}
+
 // Uint32Var defines a uint32 flag with specified name, default value, and usage string.
 // The argument p points to a uint32 variable in which to store the value of the flag.
 func (f *FlagSet) Uint32Var(p *uint32, name string, value uint32, usage string) {

--- a/uint64.go
+++ b/uint64.go
@@ -19,6 +19,10 @@ func (i *uint64Value) Set(s string) error {
 	return err
 }
 
+func (i *uint64Value) Type() string {
+	return "uint64"
+}
+
 func (i *uint64Value) String() string { return fmt.Sprintf("%v", *i) }
 
 // Uint64Var defines a uint64 flag with specified name, default value, and usage string.

--- a/uint8.go
+++ b/uint8.go
@@ -19,6 +19,10 @@ func (i *uint8Value) Set(s string) error {
 	return err
 }
 
+func (i *uint8Value) Type() string {
+	return "uint8"
+}
+
 func (i *uint8Value) String() string { return fmt.Sprintf("%v", *i) }
 
 // Uint8Var defines a uint8 flag with specified name, default value, and usage string.


### PR DESCRIPTION
The major change is a new parse function that replaces the existing. The new parse function is more tolerant of flags compared to POSIX. It treats -- and - flags as the same, supports all the different boolean assignments. 
